### PR TITLE
create the output directory if it doesn't already exist

### DIFF
--- a/src/scripts/build_tfidf.py
+++ b/src/scripts/build_tfidf.py
@@ -9,6 +9,7 @@
 
 """A script to build the tf-idf document matrices for retrieval."""
 import os
+import pathlib
 from drqascripts.retriever.build_tfidf import *
 from common.util.log_helper import LogHelper
 
@@ -59,4 +60,5 @@ if __name__ == '__main__':
         'ngram': args.ngram,
         'doc_dict': doc_dict
     }
+    pathlib.Path(args.out_dir).mkdir(parents=True, exist_ok=True) 
     retriever.utils.save_sparse_csr(filename, tfidf_mat, metadata)


### PR DESCRIPTION
Currently this script crashes on the last line (which outputs all that hard work) if the output directory doesn't exist.
This change creates the output directory in that case.